### PR TITLE
Fixed windows setup crashing (partially)

### DIFF
--- a/aldryn_installer/django/__init__.py
+++ b/aldryn_installer/django/__init__.py
@@ -23,14 +23,27 @@ def create_project(config_data):
         if config_data.project_directory:
             if not os.path.exists(config_data.project_directory):
                 os.makedirs(config_data.project_directory)
-            subprocess.check_call(["django-admin.py", "startproject",
-                                   config_data.project_name,
-                                   config_data.project_directory],
-                                   shell=True)
+
+            if sys.platform == 'win32':
+                subprocess.check_call(["django-admin.py", "startproject",
+                                       config_data.project_name,
+                                       config_data.project_directory],
+                                      shell=True)
+            else:
+                subprocess.check_call(["django-admin.py", "startproject",
+                                       config_data.project_name,
+                                       config_data.project_directory])
+
         else:
-            subprocess.check_call(["django-admin.py", "startproject",
-                                   config_data.project_name],
-                                   shell=True)
+            if sys.platform == 'win32':
+                subprocess.check_call(["django-admin.py", "startproject",
+                                       config_data.project_name],
+                                      shell=True)
+
+            else:
+                subprocess.check_call(["django-admin.py", "startproject",
+                                       config_data.project_name])
+
     except subprocess.CalledProcessError as message:
         raise EnvironmentError(message)
 


### PR DESCRIPTION
Regarding my email from yesterday, this is a quick hotfix since we need the installer for our tutorial next monday. 

Yet, that's not all there is too it. You need to make sure the python extensions and filetype are associated correctly and to the current virtualenv (I don't have the time atm to code a proper fix - sorry)

``` bash
C:\Windows\system32> assoc .py=Python.file
.py=Python.file

C:\Windows\system32> ftype Python.File="C:\Users\Username\workspace\demo\env\Scripts\python.exe" "%1" %*
Python.File="C:\Users\Username\workspace\demo\env\Scripts\python.exe" "%1" %*
```
