### PR TITLE
remove unexecuted test asserts

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -118,13 +118,12 @@ class TestConfig(BaseTestClass):
         existing_path = os.path.join(self.project_dir, prj_dir)
         os.makedirs(existing_path)
         with PatchStd(self.stdout, self.stderr):
-            with self.assertRaises(SystemExit) as error:
+            with self.assertRaises(SystemExit):
                 conf_data = config.parse([
                     '-q',
                     '--db=postgres://user:pwd@host/dbname',
                     '-p'+self.project_dir,
                     prj_dir])
-                self.assertEqual(conf_data.project_path, existing_path)
 
     def test_latest_version(self):
         self.assertEqual(less_than_version('2.4'), '2.5')
@@ -219,7 +218,5 @@ class TestConfig(BaseTestClass):
                 '-p'+self.project_dir,
                 'example_prj'])
 
-            with self.assertRaises(EnvironmentError) as error:
+            with self.assertRaises(EnvironmentError):
                 check_install(conf_data)
-
-                self.assertTrue(str(error.exception).find('MySQL  driver is not installed') > -1)


### PR DESCRIPTION
These assertions are never actiually executed, as the with used with the assertRaises simply doesn't work that way.
The block only get's executed until the config parsing where the intended exception occurs.

I thought about how to actually implement the intended tests for the right error message, but didn't come up with a proper and simple solution.

Therefor I rethought, and came to the conclusion/opinion, that it's unlikely that the config.parse() method will error out with a different exception in that situation, and it's no big loss when this detail is gone.
While totally agreeing that the more detailed checks, the better, in this case I think the tests are good enough even without the more exact checks (prove is, these checks are written, but never ever excuted, and obviously that didn't result in mayor problems yet).
