### PR TITLE
removed page cache middlewares

### DIFF
--- a/aldryn_installer/config/settings.py
+++ b/aldryn_installer/config/settings.py
@@ -6,7 +6,6 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -20,7 +19,6 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
     'cms.middleware.language.LanguageCookieMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (


### PR DESCRIPTION
The page cache middleware can be very irritating if it isn't clear that it is installed. Therefore I suggest to disable it in the standard settings.

An alternative approach would be to at least disable it for authenticated users, but that still leads to stale content being served without giving the user any indication why.
