### PR TITLE
config: cache middleware removed

### DIFF
--- a/aldryn_installer/config/settings.py
+++ b/aldryn_installer/config/settings.py
@@ -6,7 +6,6 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -20,7 +19,6 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
     'cms.middleware.language.LanguageCookieMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (


### PR DESCRIPTION
django.middleware.cache.UpdateCacheMiddleware and
django.middleware.cache.FetchFromCacheMiddleware have been removed.

Editing object in /admin does not affect the frontend when the cache is
enabled. This might be super confusing for newbies who'd like to play
with both frontend and admin editing.
