### PR TITLE
Fixes shell issue when loading starting data

### DIFF
--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -229,7 +229,9 @@ def load_starting_page(config_data):
     with chdir(config_data.project_directory):
         os.environ['DJANGO_SETTINGS_MODULE'] = (
             '{0}.settings'.format(config_data.project_name))
-        subprocess.check_call(["python", "starting_page.py"], shell=True)
-        os.remove('starting_page.py')
-        os.remove('starting_page.pyc')
-        os.remove('starting_page.json')
+        subprocess.check_call(["python", "starting_page.py"])
+        for ext in ['py', 'pyc', 'json']:
+            try:
+                os.remove('starting_page.%s' % ext)
+            except OSError:
+                pass


### PR DESCRIPTION
This PR fixes two issues introduced in https://github.com/nephila/djangocms-installer/pull/60 (No idea why this has been merged even though the tests were failing?)
- `subprocess.check_call(["python", "starting_page.py"], shell=True)` would cause python to open a shell with every argument provided (`python` and `starting_page.py`). You either have to remove `shell=True` (which is preferred) or provide the command as one string (`subprocess.check_call(["python starting_page.py"], shell=True)`).
- `os.remove('starting_page.pyc')`: `starting_page.pyc` is not always present -> raises OSException
