### PR TITLE
show_plugins compatible with Python 3

### DIFF
--- a/djangocms_installer/compat.py
+++ b/djangocms_installer/compat.py
@@ -9,6 +9,8 @@ if six.PY3:
         else:
             return value
 
+    unicode = str
+
 else:
     input = raw_input
 
@@ -17,6 +19,8 @@ else:
             return value.strip().decode("utf-8")
         else:
             return value
+
+    unicode = unicode
 
 iteritems = six.iteritems
 

--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -233,5 +233,4 @@ def show_plugins():
     """
     Shows a descriptive text about supported plugins
     """
-    sys.stdout.write(unicode(data.PLUGIN_LIST_TEXT))
-
+    sys.stdout.write(compat.unicode(data.PLUGIN_LIST_TEXT))

--- a/tests/config.py
+++ b/tests/config.py
@@ -340,6 +340,5 @@ class TestConfig(BaseTestClass):
         sys.stdout = StringIO()
         try:
             config.show_plugins()
-            value = sys.stdout.getvalue()
         finally:
             sys.stdout = sys.__stdout__


### PR DESCRIPTION
show_plugins uses `unicode`, which is not available in Py3k
