### PR TITLE
Add url to the Libaries installation issues in the documentation section.

### DIFF
--- a/djangocms_installer/install/__init__.py
+++ b/djangocms_installer/install/__init__.py
@@ -27,29 +27,29 @@ def check_install(config_data):
             im.thumbnail(size)
         except IOError as e:
             #errors.append(e.strerror)
-            errors.append("Pillow is not compiled with PNG support, see 'Libraries installation issues' documentation section.")
+            errors.append("Pillow is not compiled with PNG support, see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html.")
         try:
             im = Image.open(os.path.join(os.path.dirname(__file__), "../share/test_image.jpg"))
             im.thumbnail(size)
         except IOError as e:
             #errors.append(e.strerror)
-            errors.append("Pillow is not compiled with JPEG support, see 'Libraries installation issues' documentation section.")
+            errors.append("Pillow is not compiled with JPEG support, see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html")
     except ImportError:
-        errors.append("Pillow is not installed check for installation errors and see 'Libraries installation issues' documentation section.")
+        errors.append("Pillow is not installed check for installation errors and see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html")
 
     # PostgreSQL test
     if config_data.db_driver == 'psycopg2' and not config_data.no_db_driver:  # pragma: no cover
         try:
             import psycopg2
         except ImportError:
-            errors.append("PostgreSQL driver is not installed, but you configured a PostgreSQL database, please check your installation and see 'Libraries installation issues' documentation section.")
+            errors.append("PostgreSQL driver is not installed, but you configured a PostgreSQL database, please check your installation and see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html")
 
     # MySQL test
     if config_data.db_driver == 'MySQL-python' and not config_data.no_db_driver:  # pragma: no cover
         try:
             import MySQLdb
         except ImportError:
-            errors.append("MySQL driver is not installed, but you configured a MySQL database, please check your installation and see 'Libraries installation issues' documentation section.")
+            errors.append("MySQL driver is not installed, but you configured a MySQL database, please check your installation and see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html")
     if errors:
         raise EnvironmentError("\n".join(errors))
 


### PR DESCRIPTION
The error message for library issues is now somewhat cryptic. This would point users immediately to the correct resource.
