### PR TITLE
Using '--filer' option fails

### DIFF
--- a/djangocms_installer/config/settings.py
+++ b/djangocms_installer/config/settings.py
@@ -170,3 +170,7 @@ THUMBNAIL_PROCESSORS = (
 URLCONF = {
 
 }
+
+SOUTH_MIGRATION_MODULES = (
+    ('easy_thumbnails', 'easy_thumbnails.south_migrations'),
+)

--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -253,6 +253,8 @@ def _build_settings(config_data):
     if config_data.filer:
         text.append("THUMBNAIL_PROCESSORS = (\n%s%s\n)" % (
             spacer, (",\n" + spacer).join(["'%s'" % var for var in vars.THUMBNAIL_PROCESSORS])))
+        text.append("SOUTH_MIGRATION_MODULES = {\n%s%s\n}" % (
+            spacer, (",\n" + spacer).join(["'%s': '%s'" % item for item in vars.SOUTH_MIGRATION_MODULES])))
     return "\n\n".join(text)
 
 


### PR DESCRIPTION
Added settings for easy thumbnails and South for support with the '--filer' option.  Previously the migrate would fail without specifying the South migration modules for easythumbails.
