### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Libraries you would want to check:
 * zlib (for PNG support in ``Pillow``)
 * postgresql (for ``psycopg``)
 * libmysqlclient (for ``Mysql-Python``)
+* python-dev (for compilation and linking)
 
 For additional information, check http://djangocms-installer.readthedocs.org/en/latest/libraries.html
 


### PR DESCRIPTION
I had some problems while running `django-cms` to make a test site, namely pip throwing an installation error. Installing python-dev fixed it, so I thought I might add that to the suggested packages list.
