### PR TITLE
Pass environment to subprocesses, fix use with buildout

### DIFF
--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -314,7 +314,7 @@ def setup_database(config_data):
         os.environ['DJANGO_SETTINGS_MODULE'] = (
             '{0}.settings'.format(config_data.project_name))
         env = dict(os.environ)
-        env['PYTHONPATH'] = ':'.join(map(shlex_quote, sys.path))
+        env['PYTHONPATH'] = os.pathsep.join(map(shlex_quote, sys.path))
 
         if config_data.django_version < 1.7:
             try:
@@ -344,7 +344,7 @@ def load_starting_page(config_data):
         os.environ['DJANGO_SETTINGS_MODULE'] = (
             '{0}.settings'.format(config_data.project_name))
         env = dict(os.environ)
-        env['PYTHONPATH'] = ':'.join(map(shlex_quote, sys.path))
+        env['PYTHONPATH'] = os.pathsep.join(map(shlex_quote, sys.path))
         subprocess.check_call([sys.executable, "starting_page.py"], env=env)
         for ext in ['py', 'pyc', 'json']:
             try:


### PR DESCRIPTION
In a buildout environment, virtualenv is not enough; the sys.path is also mangled to add eggs and develop-eggs. This information is lost if the environment is not preserved, making the internal calls to "python manage.py ..." fail because they can't find the modules.
