### PR TITLE
avoid error caused by shutil.rmtree('.') which prevented EnvironmentErro...

### DIFF
--- a/djangocms_installer/main.py
+++ b/djangocms_installer/main.py
@@ -44,7 +44,7 @@ def execute():
     except Exception as e:
         # Clean up your own mess
         if os.path.exists(config_data.project_directory):
-            shutil.rmtree(config_data.project_directory)
+            shutil.rmtree(config_data.project_directory, True)
         if six.PY3:
             tb = sys.exc_info()[2]
             raise EnvironmentError("%s\nDocumentation available at http://djangocms-installer.rtfd.org" % e).with_traceback(tb)


### PR DESCRIPTION
When I tried to set up djangocms by following below tutorial:
https://github.com/divio/django-cms-tutorial

I ran into below error, and the error message wasn't too helpful.

Traceback (most recent call last):
  File "/home/kang/work/aerobook_website/env/bin/djangocms", line 11, in <module>
  File "/home/kang/work/aerobook_website/env/local/lib/python2.7/site-packages/djangocms_installer/main.py", line 47, in execute
  File "/usr/lib/python2.7/shutil.py", line 256, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/usr/lib/python2.7/shutil.py", line 254, in rmtree
    os.rmdir(path)
OSError: [Errno 22] Invalid argument: '.'

With the fix in this PR, it ran into below errors which indicated libpng-dev was missing.

  File "/home/kang/work/aerobook_website/env/bin/djangocms", line 11, in <module>
    sys.exit(execute())
  File "/home/kang/work/aerobook_website/env/local/lib/python2.7/site-packages/djangocms_installer/main.py", line 28, in execute
    install.check_install(config_data)
  File "/home/kang/work/aerobook_website/env/local/lib/python2.7/site-packages/djangocms_installer/install/__init__.py", line 51, in check_install
    raise EnvironmentError("\n".join(errors))
EnvironmentError: Pillow is not compiled with PNG support, see 'Libraries installation issues' documentation section: http://djangocms-installer.readthedocs.org/en/latest/libraries.html.





