### PR TITLE
Load jquery from google's CDN, with specific version number

### DIFF
--- a/djangocms_installer/share/templates/bootstrap/base.html
+++ b/djangocms_installer/share/templates/bootstrap/base.html
@@ -30,7 +30,7 @@
         {% block content %}
         {% endblock content %}
         </div>
-    <script src="http://code.jquery.com/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
     {% render_block "js" %}
   </body>


### PR DESCRIPTION
http://blog.jquery.com/2014/07/03/dont-use-jquery-latest-js/

Also fixes this error I get when running on https:
> Blocked loading mixed active content "http://code.jquery.com/jquery.js"[Learn More] maldive.ccnmtl.columbia.edu
> Error: Bootstrap requires jQuery