### PR TITLE
Multiline databases

### DIFF
--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import zipfile
 from six import BytesIO
 
@@ -329,7 +330,12 @@ def _build_settings(config_data):
     text.append("CMS_PERMISSION = %s" % vars.CMS_PERMISSION)
     text.append("CMS_PLACEHOLDER_CONF = %s" % vars.CMS_PLACEHOLDER_CONF)
 
-    text.append("DATABASES = {\n%s'default':\n%s%s\n}" % (spacer, spacer * 2, config_data.db_parsed))
+    text.append(textwrap.dedent("""
+        DATABASES = {
+            'default': {
+                %s
+            }
+        }""").strip() % (",\n" + spacer * 2).join(["'%s': '%s'" % (key, val) for key, val in sorted(config_data.db_parsed.items(), key=lambda x: x[0])]))
 
     if config_data.django_version >= 1.7:
         text.append("MIGRATION_MODULES = {\n%s%s\n}" % (

--- a/tests/django.py
+++ b/tests/django.py
@@ -4,6 +4,7 @@ import os.path
 import re
 import sqlite3
 import sys
+import textwrap
 
 from djangocms_installer import config, django, install
 from djangocms_installer.config.settings import (MIGRATION_MODULES_BASE,
@@ -534,3 +535,22 @@ class TestDjango(IsolatedTestClass):
         query = project_db.execute('SELECT * FROM auth_user')
         self.assertTrue(query)
 
+
+class TestBaseDjango(unittest.TestCase):
+    def test_build_settings(self):
+        """Tests django.__init__._build_settings function."""
+        config_data = config.parse(['--db=postgres://user:pwd@host:5432/dbname',
+                                    '--cms-version=stable', '--django=%s' % dj_ver,
+                                    '-q', '-p .', 'example_prj'])
+        settings = django._build_settings(config_data)
+        self.assertTrue(textwrap.dedent('''
+            DATABASES = {
+                'default': {
+                    'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                    'HOST': 'host',
+                    'NAME': 'dbname',
+                    'PASSWORD': 'pwd',
+                    'PORT': '5432',
+                    'USER': 'user'
+                }
+            }''').strip() in settings)


### PR DESCRIPTION
Set DATABASES to multiline form
```
DATABASES = {
    'default':
        {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
             'HOST': 'host',
             'NAME': 'dbname',
             'PASSWORD': 'pwd',
             'PORT': '5432',
             'USER': 'user'
        }
}
```
instead of single line:
```
DATABASES = {
    'default':
        {'NAME': 'dbname', 'ENGINE': 'django.db.backends.postgresql_psycopg2', 'PASSWORD': 'pwd', 'PORT': '5432', 'HOST': 'host', 'USER': 'user'}
}
```