### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ on how to properly setup your first django CMS project.
 Documentation
 -------------
 
-For detailed information see http://djangocms-installer.readthedocs.org
+For detailed information see https://djangocms-installer.readthedocs.io
 
 Preliminary checks and system libraries
 ---------------------------------------
@@ -68,7 +68,7 @@ Libraries you would want to check:
 * libmysqlclient (for ``Mysql``)
 * python-dev (for compilation and linking)
 
-For additional information, check http://djangocms-installer.readthedocs.org/en/latest/libraries.html
+For additional information, check https://djangocms-installer.readthedocs.io/en/latest/libraries.html
 
 Supported versions
 ------------------
@@ -114,4 +114,4 @@ Please check that the ``.py`` extension is associated correctly with Python inte
 
 
 .. _version 0.8: https://github.com/nephila/djangocms-installer/tree/release/0.8.x#supported-versions
-.. _django CMS Tutorial: http://django-cms.readthedocs.org/en/latest/introduction/index.html
+.. _django CMS Tutorial: https://django-cms.readthedocs.io/en/latest/introduction/index.html

--- a/djangocms_installer/install/__init__.py
+++ b/djangocms_installer/install/__init__.py
@@ -31,7 +31,7 @@ def check_install(config_data):
         except IOError:  # pragma: no cover
             errors.append(
                 'Pillow is not compiled with PNG support, see "Libraries installation issues" '
-                'documentation section: http://djangocms-installer.readthedocs.org/en/latest/'
+                'documentation section: https://djangocms-installer.readthedocs.io/en/latest/'
                 'libraries.html.'
             )
         try:
@@ -40,13 +40,13 @@ def check_install(config_data):
         except IOError:  # pragma: no cover
             errors.append(
                 'Pillow is not compiled with JPEG support, see "Libraries installation issues" '
-                'documentation section: http://djangocms-installer.readthedocs.org/en/latest/'
+                'documentation section: https://djangocms-installer.readthedocs.io/en/latest/'
                 'libraries.html'
             )
     except ImportError:  # pragma: no cover
         errors.append(
             'Pillow is not installed check for installation errors and see "Libraries installation'
-            ' issues" documentation section: http://djangocms-installer.readthedocs.org/en/latest/'
+            ' issues" documentation section: https://djangocms-installer.readthedocs.io/en/latest/'
             'libraries.html'
         )
 
@@ -58,7 +58,7 @@ def check_install(config_data):
             errors.append(
                 'PostgreSQL driver is not installed, but you configured a PostgreSQL database, '
                 'please check your installation and see "Libraries installation issues" '
-                'documentation section: http://djangocms-installer.readthedocs.org/en/latest/'
+                'documentation section: https://djangocms-installer.readthedocs.io/en/latest/'
                 'libraries.html'
             )
 
@@ -70,7 +70,7 @@ def check_install(config_data):
             errors.append(
                 'MySQL driver is not installed, but you configured a MySQL database, please check '
                 'your installation and see "Libraries installation issues" documentation section: '
-                'http://djangocms-installer.readthedocs.org/en/latest/libraries.html'
+                'https://djangocms-installer.readthedocs.io/en/latest/libraries.html'
             )
     if errors:  # pragma: no cover
         raise EnvironmentError('\n'.join(errors))

--- a/djangocms_installer/main.py
+++ b/djangocms_installer/main.py
@@ -48,7 +48,7 @@ def execute():
                 sys.stdout.write('aldryn boilerplate requires action before '
                                  'you can actually run the project.\n'
                                  'See documentation at '
-                                 'http://aldryn-boilerplate.readthedocs.org/'
+                                 'https://aldryn-boilerplate.readthedocs.io/'
                                  'for more information.\n')
             else:
                 sys.stdout.write('All done!\n')
@@ -59,7 +59,7 @@ def execute():
     except Exception:
         # Clean up your own mess
         install.cleanup_directory(config_data)
-        doc_message = 'Check documentation at http://djangocms-installer.rtfd.org'
+        doc_message = 'Check documentation at https://djangocms-installer.readthedocs.io'
         exception_message = '\n\n{0}\n\n{1}\n\n{0}\n\n'.format('*' * len(doc_message), doc_message)
         sys.stdout.write(exception_message)
         raise

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -96,5 +96,5 @@ advanced usage:
 .. _dj-database-url: https://github.com/kennethreitz/dj-database-url
 .. _django source: https://github.com/django/django/blob/master/django/conf/global_settings.py#L50
 .. _aldryn-boilerplate: https://github.com/aldryn/aldryn-boilerplate
-.. _aldryn-boilerplate documentation: http://aldryn-boilerplate.readthedocs.org/en/latest/general/requirements.html
+.. _aldryn-boilerplate documentation: https://aldryn-boilerplate.readthedocs.io/en/latest/general/requirements.html
 .. _aldryn-apphook-reload: https://github.com/aldryn/aldryn-apphook-reload


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.