### PR TITLE
[wip] Add Bootstrap v4 alpha

### DIFF
--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -83,7 +83,7 @@ information.
                         action='store', help='Optional project parent directory')
     parser.add_argument('--bootstrap', dest='bootstrap', action='store',
                         choices=('yes', 'no'),
-                        default='no', help='Use Twitter Bootstrap Theme')
+                        default='no', help='Use Bootstrap 4alpha Theme')
     parser.add_argument('--templates', dest='templates', action='store',
                         default='no', help='Use custom template set')
     parser.add_argument('--starting-page', dest='starting_page', action='store',

--- a/djangocms_installer/share/templates/bootstrap/base.html
+++ b/djangocms_installer/share/templates/bootstrap/base.html
@@ -5,32 +5,24 @@
         <meta charset="utf-8">
         <title>{% block title %}This is my new project home page{% endblock title %}</title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/css/bootstrap.min.css" integrity="sha384-2hfp1SzUoho7/TsGGGDaFdsuuDL0LX2hnUp6VkX3CUQ2K4K+xjboZdsXyp4oUHZj" crossorigin="anonymous">
         {% render_block "css" %}
     </head>
     <body>
         {% cms_toolbar %}
         <div class="container">
-            <div class="navbar navbar-default" role="navigation">
-                <div class="navbar-header">
-                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
-                    <a class="navbar-brand" href="#">Project name</a>
-                </div>
-                <div class="navbar-collapse collapse">
-                    <ul class="nav navbar-nav">
-                        {% show_menu 0 1 100 100 "menu.html" %}
-                    </ul>
-                </div>
-            </div>
+            <nav role="navigation" class="navbar navbar-light bg-faded">
+                <ul class="nav navbar-nav">
+                    {% show_menu 0 1 100 100 "menu.html" %}
+                </ul>
+            </nav>
             {% block content %}{% endblock content %}
         </div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
+
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js" integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU" crossorigin="anonymous"></script>
         {% render_block "js" %}
     </body>
 </html>

--- a/djangocms_installer/share/templates/bootstrap/menu.html
+++ b/djangocms_installer/share/templates/bootstrap/menu.html
@@ -1,18 +1,25 @@
 {% load i18n menu_tags cache %}
 
 {% for child in children %}
-    <li class="{% if child.ancestor %}ancestor{% endif %}
+    <li class="nav-item
+        {% if child.ancestor %} ancestor{% endif %}
         {% if child.selected %} active{% endif %}
         {% if child.children %} dropdown{% endif %}">
+
         {% if child.children %}
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                {{ child.get_menu_title }} <span class="caret"></span>
+            <a href="{{ child.get_absolute_url }}" class="nav-link dropdown-toggle"
+                data-toggle="dropdown"
+                aria-haspopup="true" aria-expanded="false">
+                {{ child.get_menu_title }}
             </a>
             <ul class="dropdown-menu">
                 {% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
             </ul>
         {% else %}
-            <a href="{{ child.get_absolute_url }}"><span>{{ child.get_menu_title }}</span></a>
+            <a href="{{ child.get_absolute_url }}" class="nav-link">
+                {{ child.get_menu_title }}
+                {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
+            </a>
         {% endif %}
     </li>
     {% if class and forloop.last and not forloop.parentloop %}{% endif %}


### PR DESCRIPTION
First step on porting the installer to Bootstrap 4

If the user choose to use Bootstrap templates, I believe he wants to use Bootstrap or override its style.
So, it is perfectly fine to have a minimal template which renders a Bootstrap navbar

What I did:
- change Bootstrap name in the wizard
- Update CDNs for bootstrap and jquery. Add CDN for tether which is now a Bootstrap dep
- Update navbar template to use new Bootstrap 4 markup (dropdown menu is supported)

Fix #260 
Fix #186 