### PR TITLE
Fix handling of project path with spaces.

### DIFF
--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -53,9 +53,10 @@ def create_project(config_data):
         if os.path.exists(p):
             start_cmd = p
             break
-    cmd_args = ' '.join([sys.executable, start_cmd, 'startproject'] + args)
+    cmd_args = [sys.executable, start_cmd, 'startproject'] + args
     if config_data.verbose:
-        sys.stdout.write('Project creation command: {0}\n'.format(cmd_args))
+        cmd_args_str = ' '.join(cmd_args)
+        sys.stdout.write('Project creation command: {0}\n'.format(cmd_args_str))
     output = subprocess.check_output(cmd_args, shell=True)
     sys.stdout.write(output.decode('utf-8'))
 


### PR DESCRIPTION
Attempt to use the installer with a path containing spaces currently results in an error.

This PR fixes this issue and is more Pythonic (see hereinafter).

According to the [Python docs](https://docs.python.org/2/library/subprocess.html#frequently-used-arguments):

> *Providing a sequence of arguments is generally preferred*, as it allows the module to take care of any required escaping and quoting of arguments (e.g. to permit spaces in file names).