### PR TITLE
Detect incompatible DJANGO_SETTINGS_MODULE

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ History
 1.1.0 (unreleased)
 ++++++++++++++++++
 
-* Add support for django CMS 3.6 (as develop version until release)
+* Added support for django CMS 3.6 (as develop version until release)
+* Added detection of incompatible DJANGO_SETTINGS_MODULE environment variable
 
 1.0.2 (2018-11-21)
 ++++++++++++++++++

--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -246,6 +246,16 @@ information.
         )
         sys.exit(6)
 
+    default_settings = '{}.settings'.format(args.project_name)
+    env_settings = os.environ.get('DJANGO_SETTINGS_MODULE', default_settings)
+    if env_settings != default_settings:
+        sys.stderr.write(
+            '`DJANGO_SETTINGS_MODULE` is currently set to \'{0}\' which is not compatible with '
+            'djangocms installer.\nPlease unset `DJANGO_SETTINGS_MODULE` and re-run the installer '
+            '\n'.format(env_settings)
+        )
+        sys.exit(7)
+
     if not getattr(args, 'requirements_file'):
         requirements = []
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,6 +50,8 @@ class BaseTestClass(unittest.TestCase):
         self._remove_project_dir()
         self.stdout = None
         self.stderr = None
+        if 'DJANGO_SETTINGS_MODULE' in os.environ:
+            del os.environ['DJANGO_SETTINGS_MODULE']
         sys.path = self.syspath
 
     def setUp(self):


### PR DESCRIPTION
if `DJANGO_SETTINGS_MODULE` is set in a way which is incompatible with django CMS installer, the install will fail with obscure errors

By checking on start, we can ensure to return a clearer error message to the user

Fix #330 