### PR TITLE
Improve settings patching

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 
 * Added support for django CMS 3.6 (as develop version until release)
 * Added detection of incompatible DJANGO_SETTINGS_MODULE environment variable
+* Added detection of mismatched Django version between currently installed and declared one
 
 1.0.2 (2018-11-21)
 ++++++++++++++++++

--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -254,7 +254,7 @@ information.
             'djangocms installer.\nPlease unset `DJANGO_SETTINGS_MODULE` and re-run the installer '
             '\n'.format(env_settings)
         )
-        sys.exit(7)
+        sys.exit(10)
 
     if not getattr(args, 'requirements_file'):
         requirements = []

--- a/djangocms_installer/config/ini.py
+++ b/djangocms_installer/config/ini.py
@@ -40,7 +40,7 @@ def parse_config_file(parser, stdin_args):
     config = ConfigParser()
     if not config.read(parsed_args.config_file):
         sys.stderr.write('Config file "{0}" doesn\'t exists\n'.format(parsed_args.config_file))
-        sys.exit(7)  # It isn't used anythere.
+        sys.exit(7)  # It isn't used anywhere.
 
     config_args = _convert_config_to_stdin(config, parser)
     return config_args

--- a/tests/config.py
+++ b/tests/config.py
@@ -308,7 +308,7 @@ class TestConfig(BaseTestClass):
                         '--db=postgres://user:pwd@host/dbname',
                         '-p'+self.project_dir,
                         prj_dir])
-        self.assertEqual(error.exception.code, 7)
+        self.assertEqual(error.exception.code, 10)
         self.assertTrue(self.stderr.getvalue().find('DJANGO_SETTINGS_MODULE') > -1)
         self.assertTrue(self.stderr.getvalue().find('some_module.settings') > -1)
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -133,8 +133,8 @@ class TestMain(IsolatedTestClass):
                 # Checking we successfully completed the whole process
                 self.assertTrue(('Get into "%s" directory and type "python manage.py runserver" to start your project' % self.project_dir) in self.stdout.getvalue())
 
-    @unittest.skipIf(sys.version_info < (3.0,),
-                     reason='django 2.1 does not support python 2.6')
+    @unittest.skipIf(sys.version_info < (3.5,),
+                     reason='django 2.1 does not support python < 3.5')
     def test_develop(self):
         with patch('sys.stdout', self.stdout):
             with patch('sys.stderr', self.stderr):


### PR DESCRIPTION
If for some reason the installed django version is different than the declared one, an invalid configuration might be generated due switch between `tuple` and `list` in `django 1.9`

This tries to detect the version mismatch and report a meaningful error, ending the installation

Fix #329 