### PR TITLE
Drop old Django versions

### DIFF
--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -306,13 +306,7 @@ information.
         else:
             requirements.append('Django<{0}'.format(less_than_version(django_version)))
 
-        if django_version == '1.8':
-            requirements.extend(data.REQUIREMENTS['django-1.8'])
-        elif django_version == '1.9':
-            requirements.extend(data.REQUIREMENTS['django-1.9'])
-        elif django_version == '1.10':
-            requirements.extend(data.REQUIREMENTS['django-1.10'])
-        elif django_version == '1.11':
+        if django_version == '1.11':
             requirements.extend(data.REQUIREMENTS['django-1.11'])
         elif django_version == '2.0':
             requirements.extend(data.REQUIREMENTS['django-2.0'])

--- a/djangocms_installer/config/data.py
+++ b/djangocms_installer/config/data.py
@@ -36,15 +36,15 @@ DJANGO_DEVELOP = 'https://github.com/django/django/archive/master.zip?{bust}'.fo
 DJANGO_BETA = 'https://github.com/django/django/archive/master.zip?{bust}'.format(**bust)
 if sys.version_info >= (3, 5):
 
-    DJANGO_SUPPORTED = ('1.8', '1.9', '1.10', '1.11', '2.0', '2.1', 'stable', 'lts')
+    DJANGO_SUPPORTED = ('1.11', '2.0', '2.1', 'stable', 'lts')
     DJANGO_STABLE = '1.11'
     DJANGO_LTS = '1.11'
 elif sys.version_info >= (3, 4):
-    DJANGO_SUPPORTED = ('1.8', '1.9', '1.10', '1.11', '2.0', 'stable', 'lts')
+    DJANGO_SUPPORTED = ('1.11', '2.0', 'stable', 'lts')
     DJANGO_STABLE = '1.11'
     DJANGO_LTS = '1.11'
 else:
-    DJANGO_SUPPORTED = ('1.8', '1.9', '1.10', '1.11', 'stable', 'lts')
+    DJANGO_SUPPORTED = ('1.11', 'stable', 'lts')
     DJANGO_STABLE = '1.11'
     DJANGO_LTS = '1.11'
 DJANGO_DEFAULT = DJANGO_STABLE
@@ -64,8 +64,8 @@ DJANGO_VERSION_MATRIX = {
     'develop': '1.11'
 }
 VERSION_MATRIX = {
-    '3.4': ('1.8', '1.11'),
-    '3.5': ('1.8', '1.11'),
+    '3.4': ('1.11', '1.11'),
+    '3.5': ('1.11', '1.11'),
     '3.6': ('1.11', '2.1'),
 }
 PACKAGE_MATRIX = {
@@ -83,18 +83,6 @@ REQUIREMENTS = {
         'six',
         'pytz',
     ],
-    'django-1.8': [
-        'django-polymorphic<2.0',
-        'django-mptt<0.9',
-    ],
-    'django-1.9': [
-        'django-polymorphic<2.0',
-        'django-mptt<0.9',
-    ],
-    'django-1.10': [
-        'django-polymorphic<2.0',
-        'django-mptt<0.9',
-    ],
     'django-1.11': [
         'django-mptt>0.9',
     ],
@@ -103,15 +91,6 @@ REQUIREMENTS = {
     ],
     'django-2.1': [
         'django-mptt>0.9',
-    ],
-    'reversion-django-1.8': [
-        'django-reversion>=1.10,<1.11',
-    ],
-    'reversion-django-1.9': [
-        'django-reversion>=1.10,<2.0',
-    ],
-    'reversion-django-1.10': [
-        'django-reversion>=2.0,<2.1',
     ],
     'reversion-django-1.11': [
         'django-reversion>=2.0,<2.1',

--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -247,10 +247,7 @@ STATICFILES_DIRS = (
         )
 
     for item in overridden_settings:
-        if declared_django_version >= LooseVersion('1.9'):
-            item_re = re.compile(r'{0} = [^\]]+\]'.format(item), re.DOTALL | re.MULTILINE)
-        else:
-            item_re = re.compile(r'{0} = [^\)]+\)'.format(item), re.DOTALL | re.MULTILINE)
+        item_re = re.compile(r'{0} = [^\]]+\]'.format(item), re.DOTALL | re.MULTILINE)
         original = item_re.sub('', original)
     # TEMPLATES is special, so custom regexp needed
     if declared_django_version >= LooseVersion('2.0'):
@@ -297,16 +294,10 @@ def _build_settings(config_data):
         dirs="os.path.join(BASE_DIR, '{0}', 'templates'),".format(config_data.project_name)
     ))
 
-    if LooseVersion(config_data.django_version) >= LooseVersion('1.10'):
-        text.append('MIDDLEWARE = [\n{0}{1}\n]'.format(
-            spacer, (',\n' + spacer).join(['\'{0}\''.format(var)
-                                           for var in vars.MIDDLEWARE_CLASSES])
-        ))
-    else:
-        text.append('MIDDLEWARE_CLASSES = [\n{0}{1}\n]'.format(
-            spacer, (',\n' + spacer).join(["'{0}'".format(var)
-                                           for var in vars.MIDDLEWARE_CLASSES])
-        ))
+    text.append('MIDDLEWARE = [\n{0}{1}\n]'.format(
+        spacer, (',\n' + spacer).join(['\'{0}\''.format(var)
+                                       for var in vars.MIDDLEWARE_CLASSES])
+    ))
 
     apps = list(vars.INSTALLED_APPS)
     apps = list(vars.CMS_3_HEAD) + apps

--- a/tests/base.py
+++ b/tests/base.py
@@ -116,10 +116,13 @@ class IsolatedTestClass(BaseTestClass):
             os.environ['VIRTUAL_ENV'] = self.virtualenv_dir
 
 
-def get_latest_django(latest_stable=False):
-    if sys.version_info < (3, 4) and not latest_stable:
-        dj_ver = '1.8'
-        match = 'Django<1.9'
+def get_latest_django(latest_stable=False, latest_1_x=False):
+    if latest_1_x:
+        dj_ver = '1.11'
+        match = 'Django<2.0'
+    elif sys.version_info < (3, 4) and not latest_stable:
+        dj_ver = '1.11'
+        match = 'Django<2.0'
     elif sys.version_info < (3, 4) and latest_stable:
         dj_ver = '1.11'
         match = 'Django<2.0'

--- a/tests/config.py
+++ b/tests/config.py
@@ -116,7 +116,7 @@ class TestConfig(BaseTestClass):
         self.assertEqual(conf_data.db, 'postgres://user:pwd@host/dbname')
         self.assertEqual(conf_data.db_driver, 'psycopg2')
 
-        dj_version = '1.8'
+        dj_version = '1.11'
         cms_version = '3.4'
         conf_data = config.parse([
             '-q',
@@ -367,9 +367,9 @@ class TestConfig(BaseTestClass):
         with self.assertRaises(RuntimeError):
             self.assertEqual(supported_versions('1.9', 'stable'), ('1.9', '3.5'))
             self.assertEqual(supported_versions('1.8', 'stable'), ('1.8', '3.5'))
-        self.assertEqual(supported_versions('1.9', '3.5'), ('1.9', '3.5'))
-        self.assertEqual(supported_versions('1.8', 'lts'), ('1.8', '3.4'))
-        self.assertEqual(supported_versions('1.8.3', 'stable'), (None, '3.6'))
+            self.assertEqual(supported_versions('1.9', '3.5'), ('1.9', '3.5'))
+            self.assertEqual(supported_versions('1.8', 'lts'), ('1.8', '3.4'))
+            self.assertEqual(supported_versions('1.8.3', 'stable'), (None, '3.6'))
 
     def test_requirements(self):
         """

--- a/tests/django.py
+++ b/tests/django.py
@@ -122,15 +122,17 @@ class TestDjango(IsolatedTestClass):
         # self.assertTrue(os.path.exists(aldryn_template))
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.10 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
-    def test_patch_110_settings(self):
+                     reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
+    def test_patch_111_settings(self):
+        dj_version, dj_match = get_latest_django(latest_stable=True)
+
         extra_path = os.path.join(os.path.dirname(__file__), 'data', 'extra_settings.py')
         config_data = config.parse(['--db=sqlite://localhost/test.db',
                                     '--lang=en', '--extra-settings=%s' % extra_path,
-                                    '--django-version=1.10',
-                                    '--cms-version=3.4', '--timezone=Europe/Moscow',
+                                    '--django-version=%s' % dj_version,
+                                    '--timezone=Europe/Moscow',
                                     '-q', '-u', '-zno', '--i18n=no',
-                                    '-p' + self.project_dir, 'example_path_110_settings'])
+                                    '-p' + self.project_dir, 'example_path_111_settings'])
         install.requirements(config_data.requirements)
         django.create_project(config_data)
         django.patch_settings(config_data)
@@ -150,15 +152,17 @@ class TestDjango(IsolatedTestClass):
         self.assertIsNone(getattr(project.settings, 'MIDDLEWARE_CLASSES', None))
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.9 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
-    def test_patch_19_34_settings(self):
+                     reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
+    def test_patch_111_34_settings(self):
+        dj_version, dj_match = get_latest_django(latest_1_x=True)
+
         extra_path = os.path.join(os.path.dirname(__file__), 'data', 'extra_settings.py')
         config_data = config.parse(['--db=sqlite://localhost/test.db',
                                     '--lang=en', '--extra-settings=%s' % extra_path,
-                                    '--django-version=1.9',
+                                    '--django-version=%s' % dj_version,
                                     '--cms-version=3.4', '--timezone=Europe/Moscow',
                                     '-q', '-u', '-zno', '--i18n=no',
-                                    '-p' + self.project_dir, 'example_path_19_settings'])
+                                    '-p' + self.project_dir, 'example_path_111_34_settings'])
         install.requirements(config_data.requirements)
         django.create_project(config_data)
         django.patch_settings(config_data)
@@ -177,18 +181,20 @@ class TestDjango(IsolatedTestClass):
         self.assertEqual(project.settings.CUSTOM_SETTINGS_VAR, True)
         self.assertEqual(project.settings.CMS_PERMISSION, False)
         self.assertEqual(set(project.settings.CMS_TEMPLATES), self.templates_basic)
-        self.assertIsNone(getattr(project.settings, 'MIDDLEWARE', None))
-        self.assertIsNotNone(getattr(project.settings, 'MIDDLEWARE_CLASSES', None))
+        self.assertIsNotNone(getattr(project.settings, 'MIDDLEWARE', None))
+        self.assertIsNone(getattr(project.settings, 'MIDDLEWARE_CLASSES', None))
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.9 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
-    def test_patch_django_19_34(self):
+                     reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
+    def test_patch_django_111_34(self):
+        dj_version, dj_match = get_latest_django(latest_1_x=True)
+
         config_data = config.parse(['--db=sqlite://localhost/test.db',
                                     '--lang=en', '--bootstrap=yes',
-                                    '--django-version=1.9',
+                                    '--django-version=%s' % dj_version,
                                     '--cms-version=3.4', '--timezone=Europe/Moscow',
                                     '-q', '-u', '-zno', '--i18n=no',
-                                    '-p' + self.project_dir, 'example_path_19'])
+                                    '-p' + self.project_dir, 'example_path_111'])
 
         install.requirements(config_data.requirements)
         django.create_project(config_data)
@@ -231,11 +237,11 @@ class TestDjango(IsolatedTestClass):
         self.assertTrue('djangocms_video' in project.settings.INSTALLED_APPS)
         self.assertTrue(
             config.get_settings().APPHOOK_RELOAD_MIDDLEWARE_CLASS_OLD not in
-            project.settings.MIDDLEWARE_CLASSES
+            project.settings.MIDDLEWARE
         )
         self.assertTrue(
             config.get_settings().APPHOOK_RELOAD_MIDDLEWARE_CLASS in
-            project.settings.MIDDLEWARE_CLASSES
+            project.settings.MIDDLEWARE
         )
         self.assertEqual(set(project.settings.CMS_TEMPLATES), self.templates_bootstrap)
 
@@ -244,30 +250,6 @@ class TestDjango(IsolatedTestClass):
         self.assertEqual(len(re.findall('STATIC_ROOT', settings)), 1)
         self.assertEqual(len(re.findall('MEDIA_ROOT =', settings)), 1)
         self.assertEqual(len(re.findall('STATICFILES_DIRS', settings)), 1)
-
-    @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.8 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
-    def test_patch_django_18_34(self):
-        extra_path = os.path.join(os.path.dirname(__file__), 'data', 'extra_settings.py')
-        config_data = config.parse(['--db=sqlite://localhost/test.db',
-                                    '--lang=en', '--extra-settings=%s' % extra_path,
-                                    '--django-version=1.8', '--cms-version=3.4',
-                                    '--timezone=Europe/Moscow',
-                                    '-q', '-u', '-zno', '--i18n=no',
-                                    '-p' + self.project_dir, 'example_path_17_settings'])
-        install.requirements(config_data.requirements)
-        django.create_project(config_data)
-        django.patch_settings(config_data)
-        django.copy_files(config_data)
-        # settings is importable even in non django environment
-        sys.path.append(config_data.project_directory)
-
-        project = __import__(config_data.project_name, globals(), locals(), [str('settings')])
-
-        # checking for django options
-        self.assertFalse('south' in project.settings.INSTALLED_APPS)
-        self.assertFalse('cms' in project.settings.MIGRATION_MODULES)
-        self.assertFalse('djangocms_text_ckeditor' in project.settings.MIGRATION_MODULES)
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
                      reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7')
@@ -365,8 +347,8 @@ class TestDjango(IsolatedTestClass):
         )
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.8 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
-    def test_patch_django_no_plugins(self):
+                     reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
+    def test_patch_django_111_no_plugins(self):
         extra_path = os.path.join(os.path.dirname(__file__), 'data', 'extra_settings.py')
         config_data = config.parse(['--db=sqlite://localhost/test.db',
                                     '--lang=en', '--extra-settings=%s' % extra_path,
@@ -406,12 +388,14 @@ class TestDjango(IsolatedTestClass):
         self.assertFalse('cms.plugins.video' in project.settings.INSTALLED_APPS)
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.8 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
+                     reason='django 1.11 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
     def test_patch(self):
+        dj_version, dj_match = get_latest_django(latest_stable=True)
+
         config_data = config.parse(['--db=sqlite://localhost/test.db',
                                     '--lang=en',
-                                    '--django-version=1.8',
-                                    '--cms-version=3.4', '--timezone=Europe/Moscow',
+                                    '--django-version=%s' % dj_version,
+                                    '--timezone=Europe/Moscow',
                                     '-f', '-q', '-u', '-zno', '--i18n=no',
                                     '-p' + self.project_dir, 'example_path_patch'])
         install.requirements(config_data.requirements)
@@ -441,7 +425,7 @@ class TestDjango(IsolatedTestClass):
             project.settings.TEMPLATES[0]['OPTIONS']['context_processors']
         )
         self.assertTrue(
-            'cms.middleware.toolbar.ToolbarMiddleware' in project.settings.MIDDLEWARE_CLASSES
+            'cms.middleware.toolbar.ToolbarMiddleware' in project.settings.MIDDLEWARE
         )
         self.assertTrue(project.settings.CMS_LANGUAGES['default']['redirect_on_fallback'])
         self.assertEqual(project.settings.CMS_LANGUAGES[1][0]['code'], 'en')
@@ -492,11 +476,12 @@ class TestDjango(IsolatedTestClass):
         del (sys.modules["%s.settings" % config_data.project_name])
 
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
-                     reason='django 1.8 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
+                     reason='django 1.111 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
     def test_database_setup_filer(self):
+        dj_version, dj_match = get_latest_django(latest_stable=True)
+
         config_data = config.parse(['--db=sqlite://localhost/test.db',
-                                    '-f', '-q', '-u', '--django-version=1.8',
-                                    '--cms-version=3.4',
+                                    '-f', '-q', '-u', '--django-version=%s' % dj_version,
                                     '-p' + self.project_dir, 'cms_project'])
         install.requirements(config_data.requirements)
         django.create_project(config_data)
@@ -538,9 +523,11 @@ class TestDjango(IsolatedTestClass):
     @unittest.skipIf(sys.version_info[:2] not in ((2, 7), (3, 4), (3, 5), (3, 6), (3, 7),),
                      reason='django 1.8 only supports python 2.7, 3.4, 3.5, 3.6 and 3.7,')
     def test_starting_page(self):
+        dj_version, dj_match = get_latest_django(latest_stable=True)
+
         config_data = config.parse(['--db=sqlite://localhost/test.db',
-                                    '-q', '-u', '--django-version=1.8',
-                                    '--cms-version=3.4', '--starting-page=yes',
+                                    '-q', '-u', '--django-version=%s' % dj_version,
+                                    '--starting-page=yes',
                                     '-p' + self.project_dir, 'cms_project'])
         install.requirements(config_data.requirements)
         django.create_project(config_data)


### PR DESCRIPTION
Just drop Django < 1.11

django CMS 3.4 / 3.5 will be dropped when 3.7 will be released