### PR TITLE
Fix postgres drivers detection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ History
 ++++++++++++++++++
 
 * Pinned formtools version on django 1.11 to avoid python 2 issues
+* Unpinned psycopg2 version for Django 2.2+
+* Support "shorthand" postgres django backend
 
 1.2.0 (2019-11-04)
 ++++++++++++++++++

--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -278,7 +278,10 @@ information.
             requirements.extend(data.REQUIREMENTS['cms-3.6'])
 
         if not args.no_db_driver:
-            requirements.append(args.db_driver)
+            if args.db_driver == 'psycopg2' and django_version in ('1.11', '2.0', '2.1'):
+                requirements.append('psycopg2<2.8')
+            else:
+                requirements.append(args.db_driver)
         if not args.no_plugins:
             if args.cms_version in ('rc', 'develop'):
                 requirements.extend(data.REQUIREMENTS['plugins-master'])

--- a/djangocms_installer/config/data.py
+++ b/djangocms_installer/config/data.py
@@ -189,7 +189,9 @@ djangocms installer will install and configure the following plugins:
 """
 
 DRIVERS = {
-    'django.db.backends.postgresql_psycopg2': 'psycopg2<2.8',
+    'django.db.backends.postgresql': 'psycopg2',
+    'django.db.backends.postgresql_psycopg2': 'psycopg2',
+    'django.contrib.gis.db.backends.postgis': 'postgis',
     'django.db.backends.postgresql_postgis': 'postgis',
     'django.db.backends.mysql': 'mysqlclient',
     'django.db.backends.sqlite3': '',

--- a/tests/base.py
+++ b/tests/base.py
@@ -116,6 +116,11 @@ class IsolatedTestClass(BaseTestClass):
 
 
 def get_latest_django(latest_stable=False, latest_1_x=False):
+    """
+    Get latest django version compatible with all the supported django CMS versions.
+
+    Takes into account arguments and python version.
+    """
     if latest_1_x:
         dj_ver = '1.11'
         match = 'Django<2.0'

--- a/tests/config.py
+++ b/tests/config.py
@@ -111,7 +111,7 @@ class TestConfig(BaseTestClass):
         self.assertEqual(conf_data.languages, ['en-ca', 'de', 'it'])
         self.assertEqual(conf_data.project_directory, self.project_dir)
         self.assertEqual(conf_data.db, 'postgres://user:pwd@host/dbname')
-        self.assertEqual(conf_data.db_driver, 'psycopg2<2.8')
+        self.assertEqual(conf_data.db_driver, 'psycopg2')
 
         dj_version, dj_match = get_latest_django(latest_stable=True)
         cms_version = 'develop'
@@ -141,7 +141,7 @@ class TestConfig(BaseTestClass):
         self.assertEqual(conf_data.languages, ['en', 'de', 'it'])
         self.assertEqual(conf_data.project_directory, self.project_dir)
         self.assertEqual(conf_data.db, 'postgres://user:pwd@host/dbname')
-        self.assertEqual(conf_data.db_driver, 'psycopg2<2.8')
+        self.assertEqual(conf_data.db_driver, 'psycopg2')
 
         dj_version = '1.11'
         cms_version = '3.7'
@@ -172,7 +172,7 @@ class TestConfig(BaseTestClass):
         self.assertEqual(conf_data.languages, ['en'])
         self.assertEqual(conf_data.project_directory, self.project_dir)
         self.assertEqual(conf_data.db, 'postgres://user:pwd@host/dbname')
-        self.assertEqual(conf_data.db_driver, 'psycopg2<2.8')
+        self.assertEqual(conf_data.db_driver, 'psycopg2')
 
     def test_version_misdj_match(self):
         with self.assertRaises(SystemExit):
@@ -470,6 +470,7 @@ class TestConfig(BaseTestClass):
         self.assertTrue(conf_data.requirements.find('cmsplugin-filer') == -1)
         self.assertTrue(conf_data.requirements.find('djangocms-file') > -1)
         self.assertTrue(conf_data.requirements.find('djangocms-text-ckeditor') > -1)
+        self.assertTrue(conf_data.requirements.find('psycopg2<2.8') > -1)
 
         conf_data = config.parse([
             '-q',
@@ -497,6 +498,8 @@ class TestConfig(BaseTestClass):
         self.assertTrue(conf_data.requirements.find('djangocms-style') > -1)
         self.assertTrue(conf_data.requirements.find('djangocms-teaser') == -1)
         self.assertTrue(conf_data.requirements.find('djangocms-video') > -1)
+        self.assertTrue(conf_data.requirements.find('psycopg2') > -1)
+        self.assertTrue(conf_data.requirements.find('psycopg2<2.8') == -1)
 
         conf_data = config.parse([
             '-q',
@@ -526,6 +529,8 @@ class TestConfig(BaseTestClass):
         self.assertTrue(conf_data.requirements.find('djangocms-style') > -1)
         self.assertTrue(conf_data.requirements.find('djangocms-teaser') == -1)
         self.assertTrue(conf_data.requirements.find('djangocms-video') > -1)
+        self.assertTrue(conf_data.requirements.find('psycopg2') > -1)
+        self.assertTrue(conf_data.requirements.find('psycopg2<2.8') == -1)
 
         with self.assertRaises(SystemExit):
             dj_version = '1.8'
@@ -684,6 +689,7 @@ class TestConfig(BaseTestClass):
         self.assertTrue(conf_data.requirements.find('south') == -1)
 
         dj_version = '2.1'
+        dj_match = 'Django<2.2'
         requirements_21 = [
             '-q',
             '--db=postgres://user:pwd@host/dbname',
@@ -709,6 +715,7 @@ class TestConfig(BaseTestClass):
             self.assertTrue(conf_data.requirements.find('djangocms-admin-style/archive/master.zip') > -1)
             self.assertTrue(conf_data.requirements.find('djangocms-teaser/archive/master.zip') == -1)
             self.assertTrue(conf_data.requirements.find('south') == -1)
+            self.assertTrue(conf_data.requirements.find('psycopg2<2.8') > -1)
 
         conf_data = config.parse([
             '-q',


### PR DESCRIPTION
* add support for 'short' postgres driver (available when next dj_database_url is released)
* don't pin psycopg2<2.8 in django 2.2+

Fix #355 
Fix #354