### PR TITLE
Installer addons PoC

### DIFF
--- a/djangocms_installer/config/__init__.py
+++ b/djangocms_installer/config/__init__.py
@@ -118,6 +118,9 @@ information.
                                            'provided values')
     parser.add_argument('--wizard', '-w', dest='wizard', action='store_true',
                         default=False, help='Run the configuration wizard')
+    parser.add_argument('--addons', '-a', dest='addons', action='append',
+                        choices=list(data.ADDONS.keys()),
+                        default=[], help='Add one of the selected addons')
     parser.add_argument('--verbose', dest='verbose', action='store_true',
                         default=False,
                         help='Be more verbose and don\'t swallow subcommands output')
@@ -301,16 +304,15 @@ information.
         else:
             requirements.append('Django<{0}'.format(less_than_version(django_version)))
 
-        if django_version == '2.2':
-            requirements.extend(data.REQUIREMENTS['django-2.2'])
-        elif django_version == '2.1':
-            requirements.extend(data.REQUIREMENTS['django-2.1'])
-        elif django_version == '2.0':
-            requirements.extend(data.REQUIREMENTS['django-2.0'])
-        elif django_version == '1.11':
-            requirements.extend(data.REQUIREMENTS['django-1.11'])
+        requirements.extend(data.REQUIREMENTS['django-%s' % django_version])
 
         requirements.extend(data.REQUIREMENTS['default'])
+
+        if args.addons:
+            for addon in args.addons:
+                requirements.extend(
+                    data.ADDONS[addon]['requirements']['django-%s' % django_version]
+                )
 
         setattr(args, 'requirements', '\n'.join(requirements).strip())
 

--- a/djangocms_installer/config/data.py
+++ b/djangocms_installer/config/data.py
@@ -159,6 +159,52 @@ REQUIREMENTS = {
     ],
 }
 
+ADDONS = {
+    'blog': {
+        'requirements': {
+            'django-1.11': [
+                'djangocms-blog',
+            ],
+            'django-2.0': [
+                'djangocms-blog',
+            ],
+            'django-2.1': [
+                'djangocms-blog',
+            ],
+            'django-2.2': [
+                'djangocms-blog',
+            ],
+        },
+        'installed_apps': [
+            'aldryn_apphooks_config',
+            'parler',
+            'taggit',
+            'taggit_autosuggest',
+            'meta',
+            'djangocms_blog',
+            'sortedm2m'
+        ],
+        'settings': """
+META_SITE_PROTOCOL = 'http'
+META_USE_SITES = True
+        """,
+        'urls': [
+            'djangocms_blog.taggit_urls'
+        ]
+
+    }
+}
+ADDONS_URLCONF = """
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.conf.urls import include, url
+
+urlpatterns = [
+    %s
+]
+"""
+
 TEMPLATES_1_8 = """
 TEMPLATES = [
     {{

--- a/djangocms_installer/config/urls_i18n.py
+++ b/djangocms_installer/config/urls_i18n.py
@@ -17,6 +17,12 @@ urlpatterns = [
         {'sitemaps': {'cmspages': CMSSitemap}}),
 ]
 
+try:
+    from .urls_addons import urlpatterns as addons_urlpatterns
+    urlpatterns.extend(addons_urlpatterns)
+except ImportError:
+    pass
+
 urlpatterns += i18n_patterns(
     url(r'^admin/', admin.site.urls),  # NOQA
     url(r'^', include('cms.urls')),

--- a/djangocms_installer/config/urls_noi18n.py
+++ b/djangocms_installer/config/urls_noi18n.py
@@ -16,6 +16,12 @@ urlpatterns = [
         {'sitemaps': {'cmspages': CMSSitemap}}),
 ]
 
+try:
+    from .urls_addons import urlpatterns as addons_urlpatterns
+    urlpatterns.extend(addons_urlpatterns)
+except ImportError:
+    pass
+
 urlpatterns += [
     url(r'^admin/', admin.site.urls),  # NOQA
     url(r'^', include('cms.urls')),

--- a/djangocms_installer/main.py
+++ b/djangocms_installer/main.py
@@ -40,6 +40,7 @@ def execute():
             django.create_project(config_data)
             django.patch_settings(config_data)
             django.copy_files(config_data)
+            django.patch_urls(config_data)
             if not config_data.no_sync:
                 django.setup_database(config_data)
             if config_data.starting_page:


### PR DESCRIPTION
Initial proof of concept for addons feature.

Addons are supported django CMS applications that are installed and preconfigured by the installer if selecte by the user.

They should really be just a list of pip packages: actual install / setup code should be in the addon itself, to decouple installer releases from each addons.

This require refactoring as helper functions to patch settings file and urlconf are not usable as a public API