### PR TITLE
Force X_FRAME_OPTIONS in settings due to different Django 3.0 default

### DIFF
--- a/djangocms_installer/django/__init__.py
+++ b/djangocms_installer/django/__init__.py
@@ -305,6 +305,7 @@ def _build_settings(config_data):
         )
     ))
 
+    text.append('X_FRAME_OPTIONS = \'SAMEORIGIN\'')
     text.append('CMS_PERMISSION = {0}'.format(vars.CMS_PERMISSION))
     text.append('CMS_PLACEHOLDER_CONF = {0}'.format(vars.CMS_PLACEHOLDER_CONF))
 

--- a/tests/django.py
+++ b/tests/django.py
@@ -624,3 +624,4 @@ class TestBaseDjango(unittest.TestCase):
                     'USER': 'user'
                 }
             }''').strip() in settings)
+        self.assertTrue('X_FRAME_OPTIONS = \'SAMEORIGIN\'' in settings)


### PR DESCRIPTION
Fix wrong `X_FRAME_OPTIONS` default in Django 3.0 as reported in #366 