### PR TITLE
Ensure staticfiles templatetag is not used

### DIFF
--- a/djangocms_installer/config/data.py
+++ b/djangocms_installer/config/data.py
@@ -117,11 +117,11 @@ REQUIREMENTS = {
         'django-reversion>=2.0,<2.1',
     ],
     'cms-3.6': [
-        'djangocms-admin-style>=1.4,<1.5',
+        'djangocms-admin-style>=1.5,<1.6',
         'django-treebeard>=4.0,<5.0',
     ],
     'cms-3.7': [
-        'djangocms-admin-style>=1.4,<1.5',
+        'djangocms-admin-style>=1.5,<1.6',
         'django-treebeard>=4.0,<5.0',
     ],
     'cms-master': [

--- a/djangocms_installer/share/templates/bootstrap/base.html
+++ b/djangocms_installer/share/templates/bootstrap/base.html
@@ -1,4 +1,4 @@
-{% load cms_tags staticfiles sekizai_tags menu_tags %}
+{% load cms_tags static sekizai_tags menu_tags %}
 <!doctype html>
 <html>
     <head>

--- a/tests/config.py
+++ b/tests/config.py
@@ -467,7 +467,7 @@ class TestConfig(BaseTestClass):
         self.assertTrue(conf_data.requirements.find('Django<2.0') > -1)
         self.assertFalse(conf_data.requirements.find('django-reversion') > -1)
         self.assertTrue(conf_data.requirements.find('djangocms-text-ckeditor>=3.7,<4.0') > -1)
-        self.assertTrue(conf_data.requirements.find('djangocms-admin-style>=1.4') > -1)
+        self.assertTrue(conf_data.requirements.find('djangocms-admin-style>=1.5') > -1)
         self.assertTrue(conf_data.requirements.find('django-filer') > -1)
         self.assertTrue(conf_data.requirements.find('cmsplugin-filer') == -1)
         self.assertTrue(conf_data.requirements.find('djangocms-file') > -1)


### PR DESCRIPTION
Fix issue with staticfiles templatetags removed in Django 3.0 as reported in #366