### PR TITLE
bugfix/390-add pytz to setup.cfg as install requires

### DIFF
--- a/changes/391.bugfix
+++ b/changes/391.bugfix
@@ -1,0 +1,2 @@
+Fix missing pytz dependency
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ classifiers =
 include_package_data = True
 install_requires =
 	dj-database-url>=0.4
+	pytz
 	six
 	tzlocal
 setup_requires =


### PR DESCRIPTION
# Description

Fix the problem with missing pytz as dependency.

## References

Fix #391 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-installer.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-installer.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
